### PR TITLE
fix: arrow icon transform

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -150,6 +150,9 @@ const CollapseMenuItem = styled(MenuItemButton)`
   @media (min-width: ${breakpoint("desktop")}) {
     display: flex;
   }
+
+  transform: ${(props) =>
+    props.isCollapsed ? "rotate(180deg)" : "rotate(0deg)"};
 `;
 
 export function SidebarNavigation() {


### PR DESCRIPTION
### CONTEXT
The arrow icon (next to "Collapse" menu) should point to the right when the menu is collapsed

### CHANGES
- add logic to change the transform property of the icon based on the isCollapsed prop.